### PR TITLE
Use jetstream for argo events bus

### DIFF
--- a/argo-ops/argo-ops-workflow-sensor.yaml
+++ b/argo-ops/argo-ops-workflow-sensor.yaml
@@ -23,6 +23,7 @@ spec:
               kind: Workflow
               metadata:
                 generateName: workflow-
+                namespace: argo-workflows
               spec:
                 entrypoint: whalesay
                 arguments:

--- a/argo-ops/default-event-bus.yaml
+++ b/argo-ops/default-event-bus.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   jetstream:
     version: 2.9.12
-    replicas: 1
+    replicas: 3

--- a/argo-ops/default-event-bus.yaml
+++ b/argo-ops/default-event-bus.yaml
@@ -3,22 +3,6 @@ kind: EventBus
 metadata:
   name: default
 spec:
-  nats:
-    native:
-      # Optional, defaults to 3. If it is < 3, set it to 3, that is the minimal requirement.
-      replicas: 3
-      # Optional, authen strategy, "none" or "token", defaults to "none"
-      auth: token
-      # containerTemplate:
-      #   resources:
-      #     requests:
-      #       cpu: "10m"
-      # metricsContainerTemplate:
-      #   resources:
-      #     requests:
-      #       cpu: "10m"
-      # antiAffinity: false
-      # persistence:
-      #   storageClassName: standard
-      #   accessMode: ReadWriteOnce
-      #   volumeSize: 10Gi
+  jetstream:
+    version: 2.9.12
+    replicas: 1


### PR DESCRIPTION
NATS STAN (palindrome?) has been deprecated, we should be using jetstream. Note that argo events will not allow jetstream to be configured with less than three replicas (that is the default but I included it for explicitness).

Also tweak the event sensor to trigger workflows in the `argo-workflows` namespace.