### PR TITLE
Stac-FastAPI as a Terraform module

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,12 @@ For accessing application 2, you can go to: `http://hello-world.local:{NGINX_NOD
 
 The local development environment includes resources for aggregating and visualizing logs and metrics. More information is available [here](./modules/monitoring/README.md).
 
+### STAC-FastAPI
+
+The local development environment includes a module for deploying STAC-FastAPI, which provides an API that exposes a STAC catalog that is persisted in a backend Postgres database with its component STAC Collections and Items. More information is available [here](./modules/stac-fastapi/README.md).
+
+You can configure whether or not STAC-FastAPI is included in deployment by setting the `deploy_stacfastapi` flag in the [inputs](./inputs.tf) file.
+
 ## Re-creating your local environment
 
 Depending on which tool you use to run Kubernetes, it is possible that you will need to re-create your

--- a/inputs.tf
+++ b/inputs.tf
@@ -66,3 +66,9 @@ variable "nginx_https_port" {
   }
   */
 }
+
+variable "deploy_stacfastapi" {
+  description = "Whether or not to deploy the STAC-FastAPI module resources"
+  type        = bool
+  default     = true
+}

--- a/modules/stac-fastapi/README.md
+++ b/modules/stac-fastapi/README.md
@@ -1,0 +1,42 @@
+# STAC-FastAPI
+
+This module installs resources that deploy the components for STAC-FastAPI. See [STAC-FastAPI](https://stac-utils.github.io/stac-fastapi/) for more details.
+
+If installing this module by itself (i.e. separately from the other modules in the parent repo), uncomment the Kubernetes and Helm provider blocks in the `providers.tf` file within this module and `cd` into the `modules/stac-fastapi` directory.
+
+## Installation
+
+1. First, initialize Terraform:
+
+```bash
+terraform init
+```
+
+2. Validate that the terraform resources are valid. If your Terraform configuration is valid the validate command will respond with _"Success! The configuration is valid."_
+
+```bash
+terraform validate
+```
+
+3. Run terraform plan. The terraform plan will give you a summary of all the changes Terraform will perform prior to deploying any change.
+
+```bash
+terraform plan
+```
+
+4. Deploy the changes by applying terraform plan. You will be asked to confirm the changes and must respond with _"yes"_.
+
+```bash
+terraform apply
+```
+
+Once installed you can verify STAC-FastAPI is running by first configuring port forwarding the PgSTAC service:
+
+`kubectl port-forward service/pgstac 5439:5439`
+
+followed by port-forwarding the STAC-FastAPI application service:
+
+`kubectl port-forward service/stac-fastapi-pgstac 8080:8080`
+
+
+Then, with your browser of choice navigate to `http://localhost:8080`.

--- a/modules/stac-fastapi/README.md
+++ b/modules/stac-fastapi/README.md
@@ -30,7 +30,7 @@ terraform plan
 terraform apply
 ```
 
-Once installed you can verify STAC-FastAPI is running by first configuring port forwarding the PgSTAC service:
+Once installed you can verify STAC-FastAPI is running by first port-forwarding the PgSTAC service:
 
 `kubectl port-forward service/pgstac 5439:5439`
 

--- a/modules/stac-fastapi/inputs.tf
+++ b/modules/stac-fastapi/inputs.tf
@@ -1,0 +1,7 @@
+variable namespace_annotations {
+  type = map(string)
+  description = "Map of annotations applied to the created namespace"
+  default = {
+    "linkerd.io/inject" = "enabled"
+  }
+}

--- a/modules/stac-fastapi/inputs.tf
+++ b/modules/stac-fastapi/inputs.tf
@@ -1,7 +1,5 @@
 variable namespace_annotations {
   type = map(string)
   description = "Map of annotations applied to the created namespace"
-  default = {
-    "linkerd.io/inject" = "enabled"
-  }
+  default = {}
 }

--- a/modules/stac-fastapi/main.tf
+++ b/modules/stac-fastapi/main.tf
@@ -1,0 +1,27 @@
+resource "kubernetes_namespace" "stac" {
+  metadata {
+    annotations = var.namespace_annotations
+
+    labels = {
+      app = "stac"
+    }
+
+    name = "stac"
+  }
+}
+
+resource "helm_release" "stac-fastapi" {
+  name = "stac-fastapi"
+  namespace = "stac"
+  repository = "https://element84.github.io/filmdrop-k8s-helm-charts/"
+  chart = "stac-fastapi"
+  atomic = true
+
+  values = [
+    file("${path.module}/values.yaml")
+  ]
+
+  depends_on = [
+    kubernetes_namespace.stac
+  ]
+}

--- a/modules/stac-fastapi/providers.tf
+++ b/modules/stac-fastapi/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}
+
+# Uncomment this portion if installing from the module directory
+
+# provider "kubernetes" {
+#   config_path = pathexpand("~/.kube/config")
+#   config_context = "rancher-desktop"
+# }
+
+# provider "helm" {
+#   kubernetes {
+#     config_path = pathexpand("~/.kube/config")
+#     config_context = "rancher-desktop"
+#   }
+# }

--- a/modules/stac-fastapi/providers.tf
+++ b/modules/stac-fastapi/providers.tf
@@ -9,7 +9,7 @@ terraform {
   }
 }
 
-# Uncomment this portion if installing from the module directory
+#Uncomment this portion if installing from the module directory
 
 # provider "kubernetes" {
 #   config_path = pathexpand("~/.kube/config")

--- a/modules/stac-fastapi/values.yaml
+++ b/modules/stac-fastapi/values.yaml
@@ -1,0 +1,2 @@
+# Add any values here that you want to override
+# from the helm chart's default values

--- a/stac-fastapi.tf
+++ b/stac-fastapi.tf
@@ -1,4 +1,5 @@
 module "stac-fastapi" {
+  count = var.deploy_stacfastapi == true ? 1 : 0
   source = "./modules/stac-fastapi"
 
   namespace_annotations = {

--- a/stac-fastapi.tf
+++ b/stac-fastapi.tf
@@ -1,0 +1,11 @@
+module "stac-fastapi" {
+  source = "./modules/stac-fastapi"
+
+  namespace_annotations = {
+    "linkerd.io/inject" = "enabled"
+  }
+
+  depends_on = [
+    helm_release.linkerd_control_plane
+  ]
+}


### PR DESCRIPTION
- Added a Terraform module that installs the STAC-FastAPI Helm Chart from the Element84 GitHub Helm Chart repository ([https://element84.github.io/filmdrop-k8s-helm-charts/](https://element84.github.io/filmdrop-k8s-helm-charts/))