### PR TITLE
KubernetesJob to initialize database

### DIFF
--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -8,14 +8,14 @@ module "db_namespace" {
 
 
 module "postgres" {
-  source  = "./postgres"
-  count   = var.deploy_postgres == true ? 1 : 0
+  source = "./postgres"
+  count  = var.deploy_postgres == true ? 1 : 0
 
-  namespace                                 = var.namespace
-  postgres_version                          = var.postgres_version
-  postgres_additional_configuration_values  = var.postgres_additional_configuration_values
-  custom_postgres_values_yaml               = var.custom_postgres_values_yaml
-  custom_input_map                          = var.custom_input_map
+  namespace                                = var.namespace
+  postgres_version                         = var.postgres_version
+  postgres_additional_configuration_values = var.postgres_additional_configuration_values
+  custom_postgres_values_yaml              = var.custom_postgres_values_yaml
+  custom_input_map                         = var.custom_input_map
 
   depends_on = [module.db_namespace]
 }

--- a/modules/db/postgres/inputs.tf
+++ b/modules/db/postgres/inputs.tf
@@ -1,44 +1,92 @@
-variable postgres_version {
-  type = string
+variable "postgres_version" {
+  type        = string
   description = "Version of Postgres Helm Chart"
-  default = "0.1.0"
+  default     = "0.1.0"
 }
 
-variable namespace {
+variable "namespace" {
   description = "Name of namespace"
   type        = string
   default     = "db"
 }
 
-variable postgres_additional_configuration_values {
+variable "postgres_additional_configuration_values" {
   type        = list(string)
   default     = []
   description = "List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple -f options."
 }
 
-variable custom_postgres_values_yaml {
+variable "custom_postgres_values_yaml" {
   type        = string
   default     = ""
   description = "Path to custom Postgres values.yaml"
 }
 
-variable custom_input_map {
-  type        = map
+variable "custom_input_map" {
+  type        = map(any)
   description = "Input values for Postgres Helm Chart"
   default = {
-    "postgres.image.repository"               = "quay.io/element84/swoop-db"
-    "postgres.image.tag"                      = "latest"
-    "postgres.container.port"                 = 5432
-    "postgres.service.type"                   = "ClusterIP"
-    "postgres.service.port"                   = 5432
-    "postgres.service.targetPort"             = 5432
-    "postgres.service.name"                   = "postgres"
-    "postgres.service.dbName"                 = "swoop"
-    "postgres.service.authMethod"             = "trust"
-    "postgres.service.dbUser"                 = "cG9zdGdyZXM="
-    "postgres.service.dbPassword"             = "cGFzc3dvcmQ="
-    "postgres.service.sslMode"                = "disable"
-    "postgres.deployment.schemaVersionTable"  = "swoop.schema_version"
-    "postgres.replicaCount"                   = 1
+    "postgres.image.repository"              = "quay.io/element84/swoop-db"
+    "postgres.image.tag"                     = "latest"
+    "postgres.container.port"                = 5432
+    "postgres.service.type"                  = "ClusterIP"
+    "postgres.service.port"                  = 5432
+    "postgres.service.targetPort"            = 5432
+    "postgres.service.name"                  = "postgres"
+    "postgres.service.dbName"                = "swoop"
+    "postgres.service.authMethod"            = "trust"
+    "postgres.service.dbUser"                = "cG9zdGdyZXM="
+    "postgres.service.dbPassword"            = "cGFzc3dvcmQ="
+    "postgres.service.sslMode"               = "disable"
+    "postgres.deployment.schemaVersionTable" = "swoop.schema_version"
+    "postgres.replicaCount"                  = 1
   }
+}
+
+variable "owner_username" {
+  description = "Username for Owner role"
+  type        = string
+  default     = "dXNlcl9vd25lcg=="
+}
+
+variable "owner_password" {
+  description = "Password for Owner role"
+  type        = string
+  default     = "cGFzc19vd25lcg=="
+}
+
+variable "api_username" {
+  description = "Username for API role"
+  type        = string
+  default     = "dXNlcl9hcGk="
+}
+
+variable "api_password" {
+  description = "Password for API role"
+  type        = string
+  default     = "cGFzc19hcGk="
+}
+
+variable "caboose_username" {
+  description = "Username for Caboose role"
+  type        = string
+  default     = "dXNlcl9jYWJvb3Nl"
+}
+
+variable "caboose_password" {
+  description = "Password for Caboose role"
+  type        = string
+  default     = "cGFzc19jYWJvb3Nl"
+}
+
+variable "conductor_username" {
+  description = "Username for Conductor role"
+  type        = string
+  default     = "dXNlcl9jb25kdWN0b3I="
+}
+
+variable "conductor_password" {
+  description = "Password for Conductor role"
+  type        = string
+  default     = "cGFzc19jb25kdWN0b3I="
 }

--- a/modules/db/postgres/inputs.tf
+++ b/modules/db/postgres/inputs.tf
@@ -43,28 +43,16 @@ variable "custom_input_map" {
   }
 }
 
-variable "postgres_default_username" {
-  description = "Default username for Postgres"
+variable "migration_username" {
+  description = "Username for Migration role"
   type        = string
-  default     = "cG9zdGdyZXM="
+  default     = "dXNlcl9taWdyYXRpb24="
 }
 
-variable "postgres_default_password" {
-  description = "Default password for Postgres"
+variable "migration_password" {
+  description = "Password for Migration role"
   type        = string
-  default     = "cGFzc3dvcmQ="
-}
-
-variable "owner_username" {
-  description = "Username for Owner role"
-  type        = string
-  default     = "dXNlcl9vd25lcg=="
-}
-
-variable "owner_password" {
-  description = "Password for Owner role"
-  type        = string
-  default     = "cGFzc19vd25lcg=="
+  default     = "cGFzc19taWdyYXRpb24="
 }
 
 variable "api_username" {

--- a/modules/db/postgres/inputs.tf
+++ b/modules/db/postgres/inputs.tf
@@ -43,6 +43,18 @@ variable "custom_input_map" {
   }
 }
 
+variable "postgres_default_username" {
+  description = "Default username for Postgres"
+  type        = string
+  default     = "cG9zdGdyZXM="
+}
+
+variable "postgres_default_password" {
+  description = "Default password for Postgres"
+  type        = string
+  default     = "cGFzc3dvcmQ="
+}
+
 variable "owner_username" {
   description = "Username for Owner role"
   type        = string

--- a/modules/db/postgres/main.tf
+++ b/modules/db/postgres/main.tf
@@ -32,6 +32,23 @@ module "dbinit" {
 
 }
 
+resource "kubernetes_secret" "db_postgres_default_un_pw" {
+  metadata {
+    name      = "postgres-default-un-pw"
+    namespace = var.namespace
+  }
+
+  binary_data = {
+    username = var.postgres_default_username
+    password = var.postgres_default_password
+  }
+
+  depends_on = [
+    helm_release.postgres
+  ]
+
+}
+
 resource "kubernetes_secret" "db_postgres_secret_owner_role" {
   metadata {
     name      = "postgres-secret-owner-role"

--- a/modules/db/postgres/main.tf
+++ b/modules/db/postgres/main.tf
@@ -1,17 +1,17 @@
 resource "helm_release" "postgres" {
-  name = "postgres"
-  namespace = var.namespace
-  repository = "https://element84.github.io/filmdrop-k8s-helm-charts"
-  chart = "postgres"
-  version = var.postgres_version
-  atomic = true
+  name             = "postgres"
+  namespace        = var.namespace
+  repository       = "https://element84.github.io/filmdrop-k8s-helm-charts"
+  chart            = "postgres"
+  version          = var.postgres_version
+  atomic           = true
   create_namespace = false
 
   dynamic "set" {
     for_each = var.custom_input_map
 
     content {
-      name = set.key
+      name  = set.key
       value = set.value
     }
   }
@@ -20,4 +20,82 @@ resource "helm_release" "postgres" {
     [var.custom_postgres_values_yaml == "" ? file("${path.module}/values.yaml") : file(var.custom_postgres_values_yaml)],
     length(var.postgres_additional_configuration_values) == 0 ? [] : var.postgres_additional_configuration_values
   )
+}
+
+module "dbinit" {
+
+  source = "../../jobs"
+  depends_on = [kubernetes_secret.db_postgres_secret_owner_role,
+    kubernetes_secret.db_postgres_secret_api_role,
+    kubernetes_secret.db_postgres_secret_caboose_role,
+  kubernetes_secret.db_postgres_secret_conductor_role]
+
+}
+
+resource "kubernetes_secret" "db_postgres_secret_owner_role" {
+  metadata {
+    name      = "postgres-secret-owner-role"
+    namespace = var.namespace
+  }
+
+  binary_data = {
+    username = "dXNlcl9vd25lcg=="
+    password = "cGFzc19vd25lcg=="
+  }
+
+  depends_on = [
+    helm_release.postgres
+  ]
+
+}
+
+resource "kubernetes_secret" "db_postgres_secret_api_role" {
+  metadata {
+    name      = "postgres-secret-api-role"
+    namespace = var.namespace
+  }
+
+  binary_data = {
+    username = "dXNlcl9hcGk="
+    password = "cGFzc19hcGk="
+  }
+
+  depends_on = [
+    helm_release.postgres
+  ]
+
+}
+
+resource "kubernetes_secret" "db_postgres_secret_caboose_role" {
+  metadata {
+    name      = "postgres-secret-caboose-role"
+    namespace = var.namespace
+  }
+
+  binary_data = {
+    username = "dXNlcl9jYWJvb3Nl"
+    password = "cGFzc19jYWJvb3Nl"
+  }
+
+  depends_on = [
+    helm_release.postgres
+  ]
+
+}
+
+resource "kubernetes_secret" "db_postgres_secret_conductor_role" {
+  metadata {
+    name      = "postgres-secret-conductor-role"
+    namespace = var.namespace
+  }
+
+  binary_data = {
+    username = "dXNlcl9jb25kdWN0b3I="
+    password = "cGFzc19jb25kdWN0b3I="
+  }
+
+  depends_on = [
+    helm_release.postgres
+  ]
+
 }

--- a/modules/db/postgres/main.tf
+++ b/modules/db/postgres/main.tf
@@ -25,39 +25,23 @@ resource "helm_release" "postgres" {
 module "dbinit" {
 
   source = "../../jobs"
-  depends_on = [kubernetes_secret.db_postgres_secret_owner_role,
+  depends_on = [kubernetes_secret.db_postgres_secret_migration_role,
     kubernetes_secret.db_postgres_secret_api_role,
     kubernetes_secret.db_postgres_secret_caboose_role,
   kubernetes_secret.db_postgres_secret_conductor_role]
 
 }
 
-resource "kubernetes_secret" "db_postgres_default_un_pw" {
+
+resource "kubernetes_secret" "db_postgres_secret_migration_role" {
   metadata {
-    name      = "postgres-default-un-pw"
+    name      = "postgres-secret-migration-role"
     namespace = var.namespace
   }
 
   binary_data = {
-    username = var.postgres_default_username
-    password = var.postgres_default_password
-  }
-
-  depends_on = [
-    helm_release.postgres
-  ]
-
-}
-
-resource "kubernetes_secret" "db_postgres_secret_owner_role" {
-  metadata {
-    name      = "postgres-secret-owner-role"
-    namespace = var.namespace
-  }
-
-  binary_data = {
-    username = var.owner_username
-    password = var.owner_password
+    username = var.migration_username
+    password = var.migration_password
   }
 
   depends_on = [

--- a/modules/db/postgres/main.tf
+++ b/modules/db/postgres/main.tf
@@ -39,8 +39,8 @@ resource "kubernetes_secret" "db_postgres_secret_owner_role" {
   }
 
   binary_data = {
-    username = "dXNlcl9vd25lcg=="
-    password = "cGFzc19vd25lcg=="
+    username = var.owner_username
+    password = var.owner_password
   }
 
   depends_on = [
@@ -56,8 +56,8 @@ resource "kubernetes_secret" "db_postgres_secret_api_role" {
   }
 
   binary_data = {
-    username = "dXNlcl9hcGk="
-    password = "cGFzc19hcGk="
+    username = var.api_username
+    password = var.api_password
   }
 
   depends_on = [
@@ -73,8 +73,8 @@ resource "kubernetes_secret" "db_postgres_secret_caboose_role" {
   }
 
   binary_data = {
-    username = "dXNlcl9jYWJvb3Nl"
-    password = "cGFzc19jYWJvb3Nl"
+    username = var.caboose_username
+    password = var.caboose_password
   }
 
   depends_on = [
@@ -90,8 +90,8 @@ resource "kubernetes_secret" "db_postgres_secret_conductor_role" {
   }
 
   binary_data = {
-    username = "dXNlcl9jb25kdWN0b3I="
-    password = "cGFzc19jb25kdWN0b3I="
+    username = var.conductor_username
+    password = var.conductor_password
   }
 
   depends_on = [

--- a/modules/jobs/dbInit.tf
+++ b/modules/jobs/dbInit.tf
@@ -28,6 +28,11 @@ resource "kubernetes_job_v1" "db-initialization" {
           }
 
           env {
+            name  = "PGPORT"
+            value = "5432"
+          }
+
+          env {
             name = "API_ROLE_USER"
             value_from {
               secret_key_ref {

--- a/modules/jobs/dbInit.tf
+++ b/modules/jobs/dbInit.tf
@@ -11,6 +11,27 @@ resource "kubernetes_job_v1" "db-initialization" {
           name    = "swoop-db"
           image   = "quay.io/element84/swoop-db"
           command = ["python", "opt/swoop/db/scripts/db-initialization.py"]
+
+          env {
+            name = "POSTGRES_DEFAULT_USERNAME"
+            value_from {
+              secret_key_ref {
+                name = "postgres-default-un-pw"
+                key  = "username"
+              }
+            }
+          }
+
+          env {
+            name = "POSTGRES_DEFAULT_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = "postgres-default-un-pw"
+                key  = "password"
+              }
+            }
+          }
+
           env {
             name = "OWNER_ROLE_USER"
             value_from {

--- a/modules/jobs/dbInit.tf
+++ b/modules/jobs/dbInit.tf
@@ -33,6 +33,11 @@ resource "kubernetes_job_v1" "db-initialization" {
           }
 
           env {
+            name  = "DATABASE_TO_CREATE"
+            value = "initdb"
+          }
+
+          env {
             name = "OWNER_ROLE_USER"
             value_from {
               secret_key_ref {

--- a/modules/jobs/dbInit.tf
+++ b/modules/jobs/dbInit.tf
@@ -13,48 +13,20 @@ resource "kubernetes_job_v1" "db-initialization" {
           command = ["python", "opt/swoop/db/scripts/db-initialization.py"]
 
           env {
-            name = "POSTGRES_DEFAULT_USERNAME"
-            value_from {
-              secret_key_ref {
-                name = "postgres-default-un-pw"
-                key  = "username"
-              }
-            }
+            name  = "PGHOST"
+            value = "postgres"
           }
 
           env {
-            name = "POSTGRES_DEFAULT_PASSWORD"
-            value_from {
-              secret_key_ref {
-                name = "postgres-default-un-pw"
-                key  = "password"
-              }
-            }
+            name  = "PGUSER"
+            value = "postgres"
           }
 
           env {
-            name  = "DATABASE_TO_CREATE"
-            value = "initdb"
+            name  = "PGDATABASE"
+            value = "swoop"
           }
 
-          env {
-            name = "OWNER_ROLE_USER"
-            value_from {
-              secret_key_ref {
-                name = "postgres-secret-owner-role"
-                key  = "username"
-              }
-            }
-          }
-          env {
-            name = "OWNER_ROLE_PASS"
-            value_from {
-              secret_key_ref {
-                name = "postgres-secret-owner-role"
-                key  = "password"
-              }
-            }
-          }
           env {
             name = "API_ROLE_USER"
             value_from {
@@ -105,6 +77,25 @@ resource "kubernetes_job_v1" "db-initialization" {
             value_from {
               secret_key_ref {
                 name = "postgres-secret-conductor-role"
+                key  = "password"
+              }
+            }
+          }
+
+          env {
+            name = "MIGRATION_ROLE_USER"
+            value_from {
+              secret_key_ref {
+                name = "postgres-secret-migration-role"
+                key  = "username"
+              }
+            }
+          }
+          env {
+            name = "MIGRATION_ROLE_PASS"
+            value_from {
+              secret_key_ref {
+                name = "postgres-secret-migration-role"
                 key  = "password"
               }
             }

--- a/modules/jobs/dbInit.tf
+++ b/modules/jobs/dbInit.tf
@@ -1,0 +1,98 @@
+resource "kubernetes_job_v1" "db-initialization" {
+  metadata {
+    name      = "db-initialization"
+    namespace = "db"
+  }
+  spec {
+    template {
+      metadata {}
+      spec {
+        container {
+          name    = "swoop-db"
+          image   = "quay.io/element84/swoop-db"
+          command = ["python", "home/db-initialization.py"]
+          env {
+            name = "OWNER_ROLE_USER"
+            value_from {
+              secret_key_ref {
+                name = "postgres-secret-owner-role"
+                key  = "username"
+              }
+            }
+          }
+          env {
+            name = "OWNER_ROLE_PASS"
+            value_from {
+              secret_key_ref {
+                name = "postgres-secret-owner-role"
+                key  = "password"
+              }
+            }
+          }
+          env {
+            name = "API_ROLE_USER"
+            value_from {
+              secret_key_ref {
+                name = "postgres-secret-api-role"
+                key  = "username"
+              }
+            }
+          }
+          env {
+            name = "API_ROLE_PASS"
+            value_from {
+              secret_key_ref {
+                name = "postgres-secret-api-role"
+                key  = "password"
+              }
+            }
+          }
+          env {
+            name = "CABOOSE_ROLE_USER"
+            value_from {
+              secret_key_ref {
+                name = "postgres-secret-caboose-role"
+                key  = "username"
+              }
+            }
+          }
+          env {
+            name = "CABOOSE_ROLE_PASS"
+            value_from {
+              secret_key_ref {
+                name = "postgres-secret-caboose-role"
+                key  = "password"
+              }
+            }
+          }
+          env {
+            name = "CONDUCTOR_ROLE_USER"
+            value_from {
+              secret_key_ref {
+                name = "postgres-secret-conductor-role"
+                key  = "username"
+              }
+            }
+          }
+          env {
+            name = "CONDUCTOR_ROLE_PASS"
+            value_from {
+              secret_key_ref {
+                name = "postgres-secret-conductor-role"
+                key  = "password"
+              }
+            }
+          }
+
+        }
+        restart_policy = "Never"
+      }
+    }
+    backoff_limit = 4
+  }
+  wait_for_completion = true
+  timeouts {
+    create = "2m"
+    update = "2m"
+  }
+}

--- a/modules/jobs/dbInit.tf
+++ b/modules/jobs/dbInit.tf
@@ -10,7 +10,7 @@ resource "kubernetes_job_v1" "db-initialization" {
         container {
           name    = "swoop-db"
           image   = "quay.io/element84/swoop-db"
-          command = ["python", "home/db-initialization.py"]
+          command = ["python", "opt/swoop/db/scripts/db-initialization.py"]
           env {
             name = "OWNER_ROLE_USER"
             value_from {


### PR DESCRIPTION
This creates a new KubernetesJob that is triggered after the creation of the K8s resources for the Swoop-DB (i.e. Postgres) helm chart. The KubernetesJob initializes a new database and creates separate roles for Owner, Swoop API, Caboose, and Conductor. The database that is created has the owner role as the owner of the database. 

The KubernetesJob gets created in the same namespace (`db`) as the postgres resources and runs on a separate pod in the same namespace.

The Swoop-DB image (`quay.io/element84/swoop-db`) should be updated to contain the new Python script that was added into it (see PR: ) before testing the performance of the KubernetesJob. 

This PR is linked with [this other PR](https://github.com/Element84/swoop-db/pull/23) that contains the actual script used by the KubernetesJob. That PR will need to be merged first as it updates the Swoop-DB image in Quay to contain the script used by the KubernetesJob.

For testing purposes (if you do not wish to push a new image to Quay first), however, you can use an image from my DockerHub registry at `sirneeraj/dbtest:neeraj5`(modify line 12 in `jobs/dbInit.tf`) - this image is the exact same as the swoop-DB Quay image except that it contains the newly added Python script at an appropriate path.