### PR TITLE
use owner role

### DIFF
--- a/modules/db/postgres/inputs.tf
+++ b/modules/db/postgres/inputs.tf
@@ -43,22 +43,22 @@ variable "custom_input_map" {
   }
 }
 
-variable "migration_username" {
-  description = "Username for Migration role"
+variable "owner_username" {
+  description = "Username for Owner role"
   type        = string
-  default     = "dXNlcl9taWdyYXRpb24="
+  default     = "c3dvb3A="
 }
 
-variable "migration_password" {
-  description = "Password for Migration role"
+variable "owner_password" {
+  description = "Password for Owner role"
   type        = string
-  default     = "cGFzc19taWdyYXRpb24="
+  default     = "cGFzc19vd25lcg=="
 }
 
 variable "api_username" {
   description = "Username for API role"
   type        = string
-  default     = "dXNlcl9hcGk="
+  default     = "c3dvb3BfYXBp"
 }
 
 variable "api_password" {
@@ -70,7 +70,7 @@ variable "api_password" {
 variable "caboose_username" {
   description = "Username for Caboose role"
   type        = string
-  default     = "dXNlcl9jYWJvb3Nl"
+  default     = "c3dvb3BfY2Fib29zZQ=="
 }
 
 variable "caboose_password" {
@@ -82,7 +82,7 @@ variable "caboose_password" {
 variable "conductor_username" {
   description = "Username for Conductor role"
   type        = string
-  default     = "dXNlcl9jb25kdWN0b3I="
+  default     = "c3dvb3BfY29uZHVjdG9y"
 }
 
 variable "conductor_password" {

--- a/modules/db/postgres/main.tf
+++ b/modules/db/postgres/main.tf
@@ -25,7 +25,7 @@ resource "helm_release" "postgres" {
 module "dbinit" {
 
   source = "../../jobs"
-  depends_on = [kubernetes_secret.db_postgres_secret_migration_role,
+  depends_on = [kubernetes_secret.db_postgres_secret_owner_role,
     kubernetes_secret.db_postgres_secret_api_role,
     kubernetes_secret.db_postgres_secret_caboose_role,
   kubernetes_secret.db_postgres_secret_conductor_role]
@@ -33,15 +33,15 @@ module "dbinit" {
 }
 
 
-resource "kubernetes_secret" "db_postgres_secret_migration_role" {
+resource "kubernetes_secret" "db_postgres_secret_owner_role" {
   metadata {
-    name      = "postgres-secret-migration-role"
+    name      = "postgres-secret-owner-role"
     namespace = var.namespace
   }
 
   binary_data = {
-    username = var.migration_username
-    password = var.migration_password
+    username = var.owner_username
+    password = var.owner_password
   }
 
   depends_on = [

--- a/modules/jobs/dbInit.tf
+++ b/modules/jobs/dbInit.tf
@@ -88,19 +88,19 @@ resource "kubernetes_job_v1" "db-initialization" {
           }
 
           env {
-            name = "MIGRATION_ROLE_USER"
+            name = "OWNER_ROLE_USER"
             value_from {
               secret_key_ref {
-                name = "postgres-secret-migration-role"
+                name = "postgres-secret-owner-role"
                 key  = "username"
               }
             }
           }
           env {
-            name = "MIGRATION_ROLE_PASS"
+            name = "OWNER_ROLE_PASS"
             value_from {
               secret_key_ref {
-                name = "postgres-secret-migration-role"
+                name = "postgres-secret-owner-role"
                 key  = "password"
               }
             }


### PR DESCRIPTION
This updates any references from 'migration' to 'owner' and updates the environment variables used by the database initialization script to use the owner role environment variables. The name of the owner role is 'swoop'.
It also updates the usernames for the application roles used by the database init job to `swoop_api,` `swoop_caboose`, and `swoop_conductor`.